### PR TITLE
add re.DOTALL for re.search

### DIFF
--- a/longvideo-reason/eval.py
+++ b/longvideo-reason/eval.py
@@ -32,14 +32,14 @@ def accuracy_reward(completions, solution, **kwargs):
         if reward == 0.0:
             try:
                 # Extract answer from solution if it has think/answer tags
-                sol_match = re.search(r"<answer>(.*?)</answer>", sol)
+                sol_match = re.search(r"<answer>(.*?)</answer>", sol, re.DOTALL)
                 ground_truth = sol_match.group(1).strip() if sol_match else sol.strip()
 
                 # Extract answer from content if it has think/answer tags
                 if "Therefore the final answer is:" in content:
-                    content_match = re.search(r"<answer>Therefore the final answer is: (.*?)</answer>", content)
+                    content_match = re.search(r"<answer>Therefore the final answer is: (.*?)</answer>", content, re.DOTALL)
                 else:
-                    content_match = re.search(r"<answer>(.*?)</answer>", content)
+                    content_match = re.search(r"<answer>(.*?)</answer>", content, re.DOTALL)
 
                 student_answer = content_match.group(1).strip() if content_match else content.strip()
 

--- a/verl/utils/dataset.py
+++ b/verl/utils/dataset.py
@@ -481,7 +481,7 @@ class RLHFDataset(Dataset):
         example["position_ids"] = position_ids
         answer = example.pop(self.answer_key)
         if "<answer>" in answer:
-            match = re.search(r"<answer>(.*?)</answer>", answer)
+            match = re.search(r"<answer>(.*?)</answer>", answer, re.DOTALL)
             example["ground_truth"] = match.group(1)
         else:
             example["ground_truth"] = answer

--- a/verl/workers/rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout_spmd.py
@@ -290,7 +290,7 @@ class vLLMRollout(BaseRollout):
                 pred_answers = []
 
                 for response in responses:
-                    content_match = re.search(r"<answer>(.*?)</answer>", response)
+                    content_match = re.search(r"<answer>(.*?)</answer>", response, re.DOTALL)
                     if content_match:
                         pred_answers.append(content_match.group(1).strip())
                     else:


### PR DESCRIPTION
Hi

Thanks for your great work!

When I use it for training, I found some missing in `re.search`. add `re.DOTALL` is more stable for extracting content from answers, as follows:
<img width="638" height="155" alt="截屏2025-08-19 18 04 31" src="https://github.com/user-attachments/assets/4820927b-8fea-4950-99ec-47eacf87f023" />

So I made some modifications in some files.

Best,

Xiaodong