### PR TITLE
fix: resolve tensor dimension mismatch when micro-batch size > 1

### DIFF
--- a/verl/trainer/core_algos.py
+++ b/verl/trainer/core_algos.py
@@ -381,6 +381,8 @@ def compute_policy_loss(
             a float number indicating the mean entropy loss
 
     """
+    if log_probs.size(0) != 0:
+        log_probs = log_probs.unsqueeze(-1)  # ensure log_probs is of shape (bs, response_length, 1)
     negative_approx_kl = log_probs - old_log_probs
     # clamp negative_approx_kl to avoid nan kld
     negative_approx_kl = torch.clamp(negative_approx_kl, -20.0, 20.0)

--- a/verl/workers/diffusion_helper.py
+++ b/verl/workers/diffusion_helper.py
@@ -70,6 +70,11 @@ def sde_step_with_logprob(
     std_dev_t = torch.sqrt(sigma / (1 - torch.where(sigma == 1, sigma_max, sigma)))*0.7
     
     # our sde
+    if std_dev_t.size(0) != 1:
+        std_dev_t= std_dev_t.unsqueeze(-1)  
+        dt= dt.unsqueeze(-1)
+        sigma = sigma.unsqueeze(-1)
+    
     prev_sample_mean = sample*(1+std_dev_t**2/(2*sigma)*dt)+model_output*(1+std_dev_t**2*(1-sigma)/(2*sigma))*dt
     
     if prev_sample is not None and generator is not None:
@@ -101,6 +106,8 @@ def sde_step_with_logprob(
     log_prob = log_prob.mean(dim=tuple(range(1, log_prob.ndim)))
     
     return prev_sample, log_prob, prev_sample_mean, std_dev_t * torch.sqrt(-1*dt)
+
+
 
 
 @torch.no_grad()


### PR DESCRIPTION
**I found when I ran wan_video_grpo.sh and set the micro_batch_size_per_device_for_update and micro_batch_size_per_device_for_experience > 1, it said:**

File "/workspace/Long-RL/verl/workers/fsdp_workers.py", line 910, in compute_ref_log_probs
(Runner pid=31520) log_probs, prev_sample_mean = self.ref_policy.compute_log_prob(data=data)
(Runner pid=31520) File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
(Runner pid=31520) return func(args, kwargs)
(Runner pid=31520) File "/workspace/Long-RL/verl/workers/actor/dp_actor.py", line 562, in compute_log_prob_diffusion
(Runner pid=31520) log_probs, prev_sample_mean = self._forward_micro_batch(model_inputs, temperature=temperature)
(Runner pid=31520) File "/workspace/Long-RL/verl/workers/actor/dp_actor.py", line 456, in _forward_micro_batch_diffusion
(Runner pid=31520) prev_sample, log_prob, prev_sample_mean, std_dev_t = compute_log_prob_flow_grpo(self.actor_module,
(Runner pid=31520) File "/workspace/Long-RL/verl/workers/diffusion_helper.py", line 638, in compute_log_prob_flow_grpo
(Runner pid=31520) prev_sample, log_prob, prev_sample_mean, std_dev_t = sde_step_with_logprob(
(Runner pid=31520) File "/workspace/Long-RL/verl/workers/diffusion_helper.py", line 73, in sde_step_with_logprob
(Runner pid=31520) prev_sample_mean = sample(1+std_dev_t*2/(2sigma)dt)+model_output(1+std_dev_t**2*(1-sigma)/(2*sigma))*dt
(Runner pid=31520) RuntimeError: The size of tensor a (16) must match the size of tensor b (4) at non-singleton dimension 1

**After a deeper investigation, I found that the issue arises when the micro-batch size is greater than 1, because the tensor broadcasting mechanism leads to a dimension mismatch. Specifically, when the micro-batch size is 1, if two tensors have different numbers of dimensions, Python will automatically expand the smaller dimension to size 1, allowing the operation to proceed. However, when the micro-batch size is greater than 1, that dimension is no longer 1, so the error occurs.
Solution: Before performing the operation, check the number of dimensions in both tensors, and if they do not match, explicitly expand the dimensions so they align correctly.**