### PR TITLE
fix: Typo 'neet' should be 'need' in chunked gathering docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ print("Response: ", response)
   - Follow `verl/utils/cache_video_embeds_vila.py` to cache video embeddings in a local directory.
   - Set `--data.cache_dir` and `--worker.actor.cached_embeds_dir` in the training script.
 - [x] **Chunked gathering**:
-- We support chunked gathering for `all_gather_data_proto`. Because it might suffer from CPU OOM if you machine do not have enough CPU memory, and also large batches or long video frames are needed. Please do the following step if you neet it.
+- We support chunked gathering for `all_gather_data_proto`. Because it might suffer from CPU OOM if you machine do not have enough CPU memory, and also large batches or long video frames are needed. Please do the following step if you need it.
   - Set `--worker.rollout.num_chunk_seq` in the training script. It can be 8/16/32. Larger ones cost less memory, but more time.
 
 ## Installation


### PR DESCRIPTION
This PR fixes a typo in `README.md`: Typo 'neet' should be 'need' in chunked gathering docs.

## Changes
- `README.md`: Typo 'neet' should be 'need' in chunked gathering docs.

## Details
```diff
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-long video frames are needed. Please do the following step if you neet it.
+long video frames are needed. Please do the following step if you need it.
```

## Tests

> Let me know if you want tests added for this fix or not.