### PR TITLE
fix: Typo 'neet' should be 'need' in open-ended reward docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ print("Response: ", response)
 
 ## Supported Features
 - [x] **Open-ended reward**: 
-- We support training for open-ended QAs (non-multi-choices QAs). Please do the following steps if you neet it.
+- We support training for open-ended QAs (non-multi-choices QAs). Please do the following steps if you need it.
   - Set `--worker.rollout.open_ended_reward=True` in the training script.
   - Export your openai API with `export OPENAI_API_KEY=xxx`.
 - [x] **Cached video embeddings**:


### PR DESCRIPTION
This PR fixes a typo in `README.md`: Typo 'neet' should be 'need' in open-ended reward docs.

## Changes
- `README.md`: Typo 'neet' should be 'need' in open-ended reward docs.

## Details
```diff
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-training for open-ended QAs (non-multi-choices QAs). Please do the following steps if you neet it.
+training for open-ended QAs (non-multi-choices QAs). Please do the following steps if you need it.
```

## Tests

> Let me know if you want tests added for this fix or not.