### PR TITLE
fix: Demo badge color 'bron' should be 'brown'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Code](https://img.shields.io/badge/GitHub-Long%20RL-blue)](https://github.com/NVlabs/Long-RL)
 [![Model](https://img.shields.io/badge/HuggingFace-Model-yellow)](https://huggingface.co/Efficient-Large-Model/LongVILA-R1-7B)
 [![Video](https://img.shields.io/badge/YouTube-Video-red)](https://www.youtube.com/watch?v=ykbblK2jiEg)
-[![Demo](https://img.shields.io/badge/Gradio-Demo-bron)](https://long-rl.hanlab.ai)
+[![Demo](https://img.shields.io/badge/Gradio-Demo-brown)](https://long-rl.hanlab.ai)
 
 <div align="center">
 


### PR DESCRIPTION
This PR corrects the documentation in `README.md`: Demo badge color 'bron' should be 'brown'.

## Changes
- `README.md`: Demo badge color 'bron' should be 'brown'.

## Details
```diff
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-[![Demo](https://img.shields.io/badge/Gradio-Demo-bron)](https://long-rl.hanlab.ai)
+[![Demo](https://img.shields.io/badge/Gradio-Demo-brown)](https://long-rl.hanlab.ai)
```

## Tests

> Let me know if you want tests added for this fix or not.